### PR TITLE
Use the SGE build of nanshe_workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/nanshe/nanshe_workflow:latest
+FROM quay.io/nanshe/nanshe_workflow:sge


### PR DESCRIPTION
Switches over to the SGE build of `nanshe/nanshe_workflow` on Quay.io. Doing this as the workflow's latest branch will be use for non-SGE builds. ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/44 ) These are useful when deploying Singularity containers to the cluster where it is not possible to use SGE in the container easily.